### PR TITLE
Remove UTF-8 BOM.

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /*
 	blogless - a blogless writing system
 	Author:  Martin Doering <martin@datenbrei.de>


### PR DESCRIPTION
index.php included a BOM `0xEF` `0xBB` `0xBF` string at the start of the file. This is where the “headers already sent” errors mentioned in #1 seem to be coming from. This pull request removes the marker.
