### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Blogless is some kind of anti-blog. No subscribers, no community stress, no excu
 
 Blogless generates static HTML pages and lets you manage them from a simple to handle online interface. New articles can be written and later changed again. All the pretty SEO stuff, like descriptions, the now useless keywords, author name and profile, open graph meta infos and all that is included without beeing in the way — automagically.
 
-##Installation
+## Installation
 Just put it in the root of you webserver and call it - manual included as index.html.
 
-##Status
+## Status
 Actually Blogless is in beta stage. It runs pretty well, but a bit of functionality is still missing. 
 
-##Prerequisites
+## Prerequisites
 Blogless needs at least PHP version 5.5, released at 20th of June 2013. Also session handling needs to be set up in php.ini. When starting, Blogless will do the needed checks automatically and tell you, if your setup is sufficient.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
